### PR TITLE
Add forwarder version

### DIFF
--- a/wallet-operations-basic.go
+++ b/wallet-operations-basic.go
@@ -124,10 +124,17 @@ func (b *BitGo) GetWalletTransferBySequenceID(walletId string, sequenceId string
 }
 
 // Create Wallet Address
+type ForwarderVersionType int
+
+const (
+	FORWARDER_VERSION_0 ForwarderVersionType = 0
+	FORWARDER_VERSION_1                      = 1
+)
 
 type AddressParams struct {
-	Chain int    `json:"chain,omitempty"`
-	Label string `json:"label,omitempty"`
+	Chain            int                  `json:"chain,omitempty"`
+	Label            string               `json:"label,omitempty"`
+	ForwarderVersion ForwarderVersionType `json:"forwarderVersion,omitempty"`
 }
 
 func (b *BitGo) CreateWalletAddress(walletId string, params *AddressParams) (address Address, err error) {

--- a/wallet-operations-basic.go
+++ b/wallet-operations-basic.go
@@ -174,7 +174,7 @@ func (b *BitGo) UpdateWalletAddress(walletId string, addressOrId string, params 
 
 type SendParams struct {
 	Address string `json:"address" valid:"required"`
-	Amount  int    `json:"amount" valid:"required"`
+	Amount  string `json:"amount" valid:"required"`
 
 	WalletPassphrase string `json:"walletPassphrase" valid:"required"`
 	Prv              string `json:"prv,omitempty"`


### PR DESCRIPTION
Add `forwarderVersion` in generating address, so that it can create new address without deploying it

doc: https://app.bitgo.com/docs/#operation/v2.wallet.newaddress